### PR TITLE
Feat/autofix artifacts

### DIFF
--- a/src/adapters/primaries/artifacts/artifacts-container.spec.tsx
+++ b/src/adapters/primaries/artifacts/artifacts-container.spec.tsx
@@ -58,7 +58,7 @@ describe('Artifacts container', () => {
     await waitFor(() => {
       wrapper.find(ArtifactsImport).find(Button).last().simulate('click');
 
-      expect(artifactsImporterSpy).toHaveBeenCalledWith(file, 1, false);
+      expect(artifactsImporterSpy).toHaveBeenCalledWith(file, 1, false, false);
     });
   });
 
@@ -67,13 +67,31 @@ describe('Artifacts container', () => {
     wrapper.find('#upload-video').simulate('change', { target: { name: '', files: [file] } });
     wrapper
       .find(Checkbox)
+      .first()
       .find('input')
       .simulate('change', { target: { name: '', checked: true } });
 
     await waitFor(() => {
       wrapper.find(ArtifactsImport).find(Button).last().simulate('click');
 
-      expect(artifactsImporterSpy).toHaveBeenCalledWith(file, 1, true);
+      expect(artifactsImporterSpy).toHaveBeenCalledWith(file, 1, true, false);
+    });
+  });
+
+  it('should import artifacts with fix ocr errors enabled', async () => {
+    const file = new File([], 'filename.mp4', { type: 'video/mp4' });
+    wrapper.find('#upload-video').simulate('change', { target: { name: '', files: [file] } });
+
+    wrapper
+      .find(Checkbox)
+      .last()
+      .find('input')
+      .simulate('change', { target: { name: '', checked: true } });
+
+    await waitFor(() => {
+      wrapper.find(ArtifactsImport).find(Button).last().simulate('click');
+
+      expect(artifactsImporterSpy).toHaveBeenCalledWith(file, 1, false, true);
     });
   });
 

--- a/src/adapters/primaries/artifacts/artifacts-container.tsx
+++ b/src/adapters/primaries/artifacts/artifacts-container.tsx
@@ -27,6 +27,7 @@ const styles = createStyles({
 type State = {
   artifactsImporter: ArtifactsImporter;
   overrideCurrentArtifacts: boolean;
+  fixOcrErrors: boolean;
   nbOfThreads: number;
   maxNbOfWorkers: number;
   video?: File;
@@ -47,6 +48,7 @@ class ArtifactsContainer extends Component<ArtifactsContainerProps, State> {
     this.state = {
       artifactsImporter: ArtifactsDI.getArtifactsImporter(),
       overrideCurrentArtifacts: false,
+      fixOcrErrors: false,
       nbOfThreads: ArtifactsDI.getArtifactsImporter().getMaxWorkers(),
       maxNbOfWorkers: ArtifactsDI.getArtifactsImporter().getMaxWorkers(),
     };
@@ -55,6 +57,7 @@ class ArtifactsContainer extends Component<ArtifactsContainerProps, State> {
     this.importArtifactsFromVideo = this.importArtifactsFromVideo.bind(this);
     this.cancelImport = this.cancelImport.bind(this);
     this.overrideArtifactsChange = this.overrideArtifactsChange.bind(this);
+    this.fixOcrErrorsChange = this.fixOcrErrorsChange.bind(this);
     this.jsonFileChange = this.jsonFileChange.bind(this);
     this.exportArtifacts = this.exportArtifacts.bind(this);
     this.onGridReady = this.onGridReady.bind(this);
@@ -86,8 +89,9 @@ class ArtifactsContainer extends Component<ArtifactsContainerProps, State> {
   }
 
   importArtifactsFromVideo(): void {
-    if (this.state.video) {
-      this.state.artifactsImporter.importFromVideo(this.state.video, this.state.nbOfThreads, this.state.overrideCurrentArtifacts);
+    const { video, nbOfThreads, overrideCurrentArtifacts, fixOcrErrors } = this.state;
+    if (video) {
+      this.state.artifactsImporter.importFromVideo(video, nbOfThreads, overrideCurrentArtifacts, fixOcrErrors);
     }
   }
 
@@ -99,6 +103,13 @@ class ArtifactsContainer extends Component<ArtifactsContainerProps, State> {
     this.setState((state) => ({
       ...state,
       overrideCurrentArtifacts: checked,
+    }));
+  }
+
+  fixOcrErrorsChange(checked: boolean): void {
+    this.setState((state) => ({
+      ...state,
+      fixOcrErrors: checked,
     }));
   }
 
@@ -212,6 +223,7 @@ class ArtifactsContainer extends Component<ArtifactsContainerProps, State> {
           importArtifacts={this.importArtifactsFromVideo}
           cancelImport={this.cancelImport}
           overrideArtifactsChanged={this.overrideArtifactsChange}
+          fixOcrErrorsChanged={this.fixOcrErrorsChange}
         ></ArtifactsImport>
         <Container>
           <div className={classes.actionsContainer}>

--- a/src/adapters/primaries/artifacts/components/artifacts-import-infos.tsx
+++ b/src/adapters/primaries/artifacts/components/artifacts-import-infos.tsx
@@ -3,8 +3,12 @@ import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core';
 
 const styles = ({ palette }: Theme) =>
   createStyles({
+    container: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
     importInfos: {
-      margin: '0 10px',
+      margin: '5px 30px 0 10px',
     },
     artifactsInError: {
       color: palette.error.light,
@@ -20,7 +24,7 @@ interface ArtifactsImportInfosProps extends WithStyles<typeof styles> {
 function ArtifactsImportInfos(props: ArtifactsImportInfosProps): ReactElement {
   const { foundFrames, importedArtifacts, artifactsInError, classes } = props;
   return (
-    <div>
+    <div className={classes.container}>
       <span className={classes.importInfos}>Found frames: {foundFrames}</span>
       <span className={classes.importInfos}>Imported artifacts: {importedArtifacts}</span>
       <span className={artifactsInError > 0 ? classes.importInfos + ' ' + classes.artifactsInError : classes.importInfos}>

--- a/src/adapters/primaries/artifacts/components/artifacts-import.tsx
+++ b/src/adapters/primaries/artifacts/components/artifacts-import.tsx
@@ -2,19 +2,34 @@ import { ChangeEvent, ReactElement } from 'react';
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { Container, createStyles, Theme, withStyles, WithStyles } from '@material-ui/core';
+import { Container, InputLabel, createStyles, Theme, withStyles, WithStyles } from '@material-ui/core';
 import { ImportInfos } from '../../../redux/artifacts/artifacts-reducer';
 import ArtifactsImportInfos from './artifacts-import-infos';
 import FormSelect from '../../shared/form-select';
 import RunButtons from '../../shared/run-buttons';
+import HelpIconTooltip from '../../shared/help-icon-tooltip';
 
 const styles = ({ palette }: Theme) =>
   createStyles({
     container: {
       marginBottom: 20,
+      display: 'flex',
+      justifyContent: 'space-between',
+    },
+    importFlex: {
+      display: 'flex',
+      alignItems: 'flex-end',
+    },
+    leftSide: {
+      flexDirection: 'column',
+      justifyContent: 'space-around',
+    },
+    rightSide: {
+      flexDirection: 'row',
     },
     uploadVideo: {
-      alignSelf: 'center',
+      alignSelf: 'flex-start',
+      margin: '10px 0',
     },
     uploadVideoInput: {
       display: 'none',
@@ -27,14 +42,12 @@ const styles = ({ palette }: Theme) =>
       textOverflow: 'ellipsis',
       width: 200,
     },
-    threadsSelect: {
-      flex: 1,
-      maxWidth: 172,
-    },
-    importFlex: {
+    importCheckboxes: {
       display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'flex-end',
+    },
+    ocrCheckboxLabel: {
+      position: 'relative',
+      top: 2,
     },
   });
 
@@ -49,6 +62,7 @@ interface ArtifactsImportProps extends WithStyles<typeof styles> {
   importArtifacts: () => void;
   cancelImport: () => void;
   overrideArtifactsChanged: (checked: boolean) => void;
+  fixOcrErrorsChanged: (checked: boolean) => void;
 }
 
 function ArtifactsImport(props: ArtifactsImportProps): ReactElement {
@@ -79,8 +93,12 @@ function ArtifactsImport(props: ArtifactsImportProps): ReactElement {
     props.overrideArtifactsChanged(event.target.checked);
   };
 
+  const handleFixOcrErrorsChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    props.fixOcrErrorsChanged(event.target.checked);
+  };
+
   const videoName = video ? video.name : '';
-  const tooltip = (
+  const threadTooltip = (
     <div>
       The more threads you use, the faster the import will be.
       <br />
@@ -88,9 +106,18 @@ function ArtifactsImport(props: ArtifactsImportProps): ReactElement {
     </div>
   );
 
+  const fixOcrTooltip = (
+    <div>
+      Unrecognized main stat value will be determined from the artifact's level.
+      <br />
+      Unrecognized artifact type, stats type or set will be fixed if more than 80% of the characters are matching an existing artifact type,
+      stats type or set.
+    </div>
+  );
+
   return (
     <Container className={classes.container}>
-      <div className={classes.importFlex}>
+      <div className={`${classes.importFlex} ${classes.leftSide}`}>
         <label className={classes.uploadVideo} htmlFor="upload-video">
           <input
             className={classes.uploadVideoInput}
@@ -107,22 +134,20 @@ function ArtifactsImport(props: ArtifactsImportProps): ReactElement {
           <input className={classes.videoNameInput} id="video-name" name="video-name" type="text" value={videoName} disabled={true} />
         </label>
 
-        <div className={classes.threadsSelect}>
-          <FormSelect
-            label="Threads"
-            options={nbThreadsOptions}
-            selectedValue={nbOfThreads}
-            tooltipText={tooltip}
-            onChange={(e) => handleNbThreadsChange(e)}
-          ></FormSelect>
+        <div className={classes.importCheckboxes}>
+          <FormControlLabel
+            control={<Checkbox onChange={handleOverrideArtifactsChange} name="override-artifacts" />}
+            label="Override current artifacts"
+          />
+          <Checkbox id="fix-ocr-checkbox" name="fix-ocr-errors" onChange={handleFixOcrErrorsChange} />
+          <InputLabel htmlFor="fix-ocr-checkbox" className={classes.ocrCheckboxLabel}>
+            Try to fix recognition errors
+            {<HelpIconTooltip tooltipText={fixOcrTooltip}></HelpIconTooltip>}
+          </InputLabel>
         </div>
       </div>
 
-      <div className={classes.importFlex}>
-        <FormControlLabel
-          control={<Checkbox onChange={handleOverrideArtifactsChange} name="override-artifacts" />}
-          label="Override current artifacts"
-        />
+      <div className={`${classes.importFlex} ${classes.rightSide}`}>
         {video ? (
           <ArtifactsImportInfos
             foundFrames={importInfos.foundFrames}
@@ -130,13 +155,22 @@ function ArtifactsImport(props: ArtifactsImportProps): ReactElement {
             artifactsInError={importInfos.artifactsInError}
           ></ArtifactsImportInfos>
         ) : null}
-        <RunButtons
-          runButtonLabel="Import Artifacts"
-          canRun={!!video}
-          isRunning={isImportRunning}
-          runClicked={importArtifacts}
-          cancelClicked={cancelImport}
-        ></RunButtons>
+        <div>
+          <FormSelect
+            label="Threads"
+            options={nbThreadsOptions}
+            selectedValue={nbOfThreads}
+            tooltipText={threadTooltip}
+            onChange={(e) => handleNbThreadsChange(e)}
+          ></FormSelect>
+          <RunButtons
+            runButtonLabel="Import Artifacts"
+            canRun={!!video}
+            isRunning={isImportRunning}
+            runClicked={importArtifacts}
+            cancelClicked={cancelImport}
+          ></RunButtons>
+        </div>
       </div>
     </Container>
   );

--- a/src/adapters/redux/artifacts/artifacts-action.ts
+++ b/src/adapters/redux/artifacts/artifacts-action.ts
@@ -20,7 +20,7 @@ export const incrementArtifactsInError = createAction('[Entities/Artifacts] Incr
 
 export const importArtifactsDoneAction = createAction('[Entities/Artifacts] Import Artifacts Done');
 
-export const runOcrOnImageAction = createAction<FrameData>('[Entities/Artifacts] Run OCR On Image');
+export const runOcrOnImageAction = createAction<{ frameData: FrameData; fixOcrErrors: boolean }>('[Entities/Artifacts] Run OCR On Image');
 
 export type ArtifactsActionTypes =
   | typeof addAllArtifactsAction

--- a/src/adapters/redux/artifacts/artifacts-middleware.ts
+++ b/src/adapters/redux/artifacts/artifacts-middleware.ts
@@ -17,7 +17,8 @@ import { selectAllArtifacts } from './artifacts-selectors';
 export const artifactsMiddleware: Middleware<void, AppState> = ({ dispatch }) => (next) => async (action) => {
   switch (action.type) {
     case runOcrOnImageAction.type: {
-      const ocrResults = await ArtifactsDI.getArtifactImageOcr().runArtifactOcrFromImage(action.payload);
+      const { frameData, fixOcrErrors } = action.payload;
+      const ocrResults = await ArtifactsDI.getArtifactImageOcr().runArtifactOcrFromImage(frameData, fixOcrErrors);
       if (ocrResults.artifact) {
         dispatch(addOneArtifactAction(ocrResults.artifact));
       }

--- a/src/domain/artifacts/artifact-images-ocr.ts
+++ b/src/domain/artifacts/artifact-images-ocr.ts
@@ -81,11 +81,12 @@ export class ArtifactImageOcr {
   private async runOcrRecognize(imageForOcr: Buffer, fixOcrErrors: boolean): Promise<ArtifactData | undefined> {
     const ocrResults = await this.ocrWorker.recognize(imageForOcr);
     const parsedOcrResults = this.ocrResultsParser.parseToArtifactData(ocrResults, fixOcrErrors);
-    const artifactData = ArtifactMapper.mapNewDataToArtifactData(parsedOcrResults);
+    const artifactData = ArtifactMapper.mapOcrDataToArtifactData(parsedOcrResults, fixOcrErrors);
 
     if (!(artifactData instanceof ArtifactValidationError)) {
       return artifactData;
     }
+
     console.error('error while parsing artifact', artifactData.getMessages());
   }
 

--- a/src/domain/artifacts/artifact-images-ocr.ts
+++ b/src/domain/artifacts/artifact-images-ocr.ts
@@ -38,15 +38,18 @@ export class ArtifactImageOcr {
     });
   }
 
-  public async runArtifactOcrFromImage(imageData: {
-    frame: string;
-    isLast: boolean;
-  }): Promise<{ artifact?: ArtifactData; inError: boolean; isDone: boolean }> {
+  public async runArtifactOcrFromImage(
+    imageData: {
+      frame: string;
+      isLast: boolean;
+    },
+    fixOcrErrors: boolean,
+  ): Promise<{ artifact?: ArtifactData; inError: boolean; isDone: boolean }> {
     this.recognizingImagesCount++;
     let artifact: ArtifactData | undefined;
     const imageForOcr = await this.getImageForOcr(imageData.frame);
     if (imageForOcr.length) {
-      artifact = await this.runOcrRecognize(imageForOcr);
+      artifact = await this.runOcrRecognize(imageForOcr, fixOcrErrors);
     }
 
     const isDone = this.areAllImagesProcessed(imageData.isLast) || this.cancelImport;
@@ -75,9 +78,9 @@ export class ArtifactImageOcr {
     return Buffer.from([]);
   }
 
-  private async runOcrRecognize(imageForOcr: Buffer): Promise<ArtifactData | undefined> {
+  private async runOcrRecognize(imageForOcr: Buffer, fixOcrErrors: boolean): Promise<ArtifactData | undefined> {
     const ocrResults = await this.ocrWorker.recognize(imageForOcr);
-    const parsedOcrResults = this.ocrResultsParser.parseToArtifactData(ocrResults);
+    const parsedOcrResults = this.ocrResultsParser.parseToArtifactData(ocrResults, fixOcrErrors);
     const artifactData = ArtifactMapper.mapNewDataToArtifactData(parsedOcrResults);
     if (!(artifactData instanceof ArtifactValidationError)) {
       return artifactData;

--- a/src/domain/artifacts/artifact-images-ocr.ts
+++ b/src/domain/artifacts/artifact-images-ocr.ts
@@ -82,10 +82,11 @@ export class ArtifactImageOcr {
     const ocrResults = await this.ocrWorker.recognize(imageForOcr);
     const parsedOcrResults = this.ocrResultsParser.parseToArtifactData(ocrResults, fixOcrErrors);
     const artifactData = ArtifactMapper.mapNewDataToArtifactData(parsedOcrResults);
+
     if (!(artifactData instanceof ArtifactValidationError)) {
       return artifactData;
     }
-    console.log('error while parsing artifact', artifactData.getMessages());
+    console.error('error while parsing artifact', artifactData.getMessages());
   }
 
   private areAllImagesProcessed(isLast: boolean): boolean {

--- a/src/domain/artifacts/artifacts-validator.ts
+++ b/src/domain/artifacts/artifacts-validator.ts
@@ -21,10 +21,10 @@ export class ArtifactValidator {
     return this.errorMessages.length === 0;
   }
 
-  public isNewArtifactValid(newArtifactData: Partial<NewArtifactData>, mainStatValue: number, mainValueFromOcr?: number): boolean {
+  public isNewArtifactValid(newArtifactData: Partial<NewArtifactData>, mainStatValue: number): boolean {
     this.errorMessages = [];
     this.validateArtifact(newArtifactData);
-    this.validateMainStatValue(newArtifactData, mainStatValue, mainValueFromOcr);
+    this.validateMainStatValue(newArtifactData, mainStatValue);
 
     return this.errorMessages.length === 0;
   }
@@ -87,13 +87,13 @@ export class ArtifactValidator {
     }
   }
 
-  private validateMainStatValue(artifactData: Partial<NewArtifactData>, mainStatValue: number, mainValueFromOcr?: number) {
+  private validateMainStatValue(artifactData: Partial<NewArtifactData>, mainStatValue: number) {
     const { level, mainStatType } = artifactData;
 
     if (!mainStatValue) {
       this.errorMessages.push(`could not find values for main stat ${mainStatType} at level ${level}.`);
     }
-    if (mainValueFromOcr && mainStatValue !== mainValueFromOcr) {
+    if (mainStatValue !== artifactData.mainStatValue) {
       this.errorMessages.push(`inconsistent main stat value, value from level is ${mainStatValue}`);
     }
   }

--- a/src/domain/artifacts/ocr-results-parser.spec.ts
+++ b/src/domain/artifacts/ocr-results-parser.spec.ts
@@ -1,5 +1,6 @@
 import {
   artifactWith2LinesNameMock,
+  artifactWithWrongTypeMock,
   misrecognizedMainImportedArtifactMock,
   misrecognizedSubsImportedArtifactMock,
   properlyImportedArtifactMock,
@@ -9,6 +10,7 @@ import {
   ocrResultsWith2LinesNameMock,
   wrongMainValuesOcrResultsMock,
   wrongSubsOcrResultsMock,
+  wrongTypeOcrResultsMock,
 } from '../../test/ocr-results-mock';
 import { OcrResultsParser } from './ocr-results-parser';
 
@@ -21,23 +23,27 @@ describe('OcrResultsParser', () => {
 
   it('should parse artifacts properly recognized', () => {
     goodOcrResultsMock.forEach((ocrResults, index) => {
-      expect(ocrResultsParser.parseToArtifactData(ocrResults)).toEqual(properlyImportedArtifactMock[index]);
+      expect(ocrResultsParser.parseToArtifactData(ocrResults, false)).toEqual(properlyImportedArtifactMock[index]);
     });
   });
 
   it('should parse artifacts main stats when not properly recognized', () => {
     wrongMainValuesOcrResultsMock.forEach((ocrResults, index) => {
-      expect(ocrResultsParser.parseToArtifactData(ocrResults)).toEqual(misrecognizedMainImportedArtifactMock[index]);
+      expect(ocrResultsParser.parseToArtifactData(ocrResults, false)).toEqual(misrecognizedMainImportedArtifactMock[index]);
     });
   });
 
   it('should parse artifacts sub stats when not properly recognized', () => {
     wrongSubsOcrResultsMock.forEach((ocrResults, index) => {
-      expect(ocrResultsParser.parseToArtifactData(ocrResults)).toEqual(misrecognizedSubsImportedArtifactMock[index]);
+      expect(ocrResultsParser.parseToArtifactData(ocrResults, false)).toEqual(misrecognizedSubsImportedArtifactMock[index]);
     });
   });
 
   it('should parse an artifact with 2 lines name', () => {
-    expect(ocrResultsParser.parseToArtifactData(ocrResultsWith2LinesNameMock)).toEqual(artifactWith2LinesNameMock);
+    expect(ocrResultsParser.parseToArtifactData(ocrResultsWith2LinesNameMock, false)).toEqual(artifactWith2LinesNameMock);
+  });
+
+  it('should parse an artifact with wrong type if fix ocr errors', () => {
+    expect(ocrResultsParser.parseToArtifactData(wrongTypeOcrResultsMock, true)).toEqual(artifactWithWrongTypeMock);
   });
 });

--- a/src/domain/artifacts/ocr-results-parser.spec.ts
+++ b/src/domain/artifacts/ocr-results-parser.spec.ts
@@ -1,6 +1,6 @@
 import {
   artifactWith2LinesNameMock,
-  artifactWithWrongTypeMock,
+  artifactWithFixableOcrResultsMock,
   misrecognizedMainImportedArtifactMock,
   misrecognizedSubsImportedArtifactMock,
   properlyImportedArtifactMock,
@@ -10,7 +10,7 @@ import {
   ocrResultsWith2LinesNameMock,
   wrongMainValuesOcrResultsMock,
   wrongSubsOcrResultsMock,
-  wrongTypeOcrResultsMock,
+  fixableStringsOcrResultsMock,
 } from '../../test/ocr-results-mock';
 import { OcrResultsParser } from './ocr-results-parser';
 
@@ -43,7 +43,7 @@ describe('OcrResultsParser', () => {
     expect(ocrResultsParser.parseToArtifactData(ocrResultsWith2LinesNameMock, false)).toEqual(artifactWith2LinesNameMock);
   });
 
-  it('should parse an artifact with wrong type if fix ocr errors', () => {
-    expect(ocrResultsParser.parseToArtifactData(wrongTypeOcrResultsMock, true)).toEqual(artifactWithWrongTypeMock);
+  it('should parse and fix error of an artifact with wrong type, set and stats types', () => {
+    expect(ocrResultsParser.parseToArtifactData(fixableStringsOcrResultsMock, true)).toEqual(artifactWithFixableOcrResultsMock);
   });
 });

--- a/src/test/imported-artifacts-data-mock.ts
+++ b/src/test/imported-artifacts-data-mock.ts
@@ -283,6 +283,7 @@ export const misrecognizedSubsImportedArtifactMock: NewArtifactData[] = [
     },
   },
 ];
+
 export const artifactWith2LinesNameMock = {
   type: ArtifactType.flower,
   set: SetNames.viridescentVenerer,
@@ -308,5 +309,18 @@ export const artifactWithFixableOcrResultsMock = {
     [SubStats.critDmg]: 7.0,
     [SubStats.elementalMastery]: 37,
     [SubStats.flatAtk]: 37,
+  },
+};
+
+export const artifactWithFixableMainOcrResultsMock = {
+  type: ArtifactType.goblet,
+  set: SetNames.bloodstainedChivalry,
+  level: 0,
+  mainStatType: MainStats.percentDef,
+  subStats: {
+    [SubStats.elementalMastery]: 23,
+    [SubStats.flatDef]: 23,
+    [SubStats.percentHp]: 4.1,
+    [SubStats.flatAtk]: 19,
   },
 };

--- a/src/test/imported-artifacts-data-mock.ts
+++ b/src/test/imported-artifacts-data-mock.ts
@@ -296,3 +296,17 @@ export const artifactWith2LinesNameMock = {
     [SubStats.flatAtk]: 37,
   },
 };
+
+export const artifactWithFixableOcrResultsMock = {
+  type: ArtifactType.sands,
+  set: SetNames.viridescentVenerer,
+  level: 12,
+  mainStatType: MainStats.percentAtk,
+  mainStatValue: 30.8,
+  subStats: {
+    [SubStats.critRate]: 7.0,
+    [SubStats.critDmg]: 7.0,
+    [SubStats.elementalMastery]: 37,
+    [SubStats.flatAtk]: 37,
+  },
+};

--- a/src/test/ocr-results-mock.ts
+++ b/src/test/ocr-results-mock.ts
@@ -329,3 +329,18 @@ export const fixableStringsOcrResultsMock = [
   'Viridescemt Venener:\n',
   '+ Equipped: Venti\n',
 ];
+
+export const wrongMainValueOcrResultsMock = [
+  "Bloodstained Chevalier's Goblet\n",
+  'Goblet of Eonothem\n',
+  'DEF\n',
+  '0.7%\n',
+  '+0\n',
+  '. Elemental Mastery+23\n',
+  '. DEF+23\n',
+  ' HP+4.14\n',
+  ' . ATK+19\n',
+  'Bloodstained Chivalry:\n',
+  'the Bloodstained Knight. Its\n',
+  'exterior has been stained as black\n',
+];

--- a/src/test/ocr-results-mock.ts
+++ b/src/test/ocr-results-mock.ts
@@ -315,3 +315,17 @@ export const ocrResultsWith2LinesNameMock = [
   'Viridescent Venerer:\n',
   '+ Equipped: Venti\n',
 ];
+
+export const fixableStringsOcrResultsMock = [
+  'In Remembrance of Viridescent\n',
+  'Sonds of Eon\n',
+  '4TK\n',
+  '30.8%\n',
+  '+12\n\n',
+  '. CRIT Rate+7.0%\n',
+  '. CRIT DNG+7.05%\n',
+  '. Elenmental Masterg+37\n',
+  '. ATK+37\n',
+  'Viridescemt Venener:\n',
+  '+ Equipped: Venti\n',
+];

--- a/src/usescases/artifacts/artifacts-importer.spec.ts
+++ b/src/usescases/artifacts/artifacts-importer.spec.ts
@@ -5,7 +5,7 @@ import artifact0 from '../../test/artifact0.jpg';
 import artifact0bis from '../../test/artifact0bis.jpg';
 import artifact1 from '../../test/artifact1.jpg';
 import artifactWithError from '../../test/artifact-error.jpg';
-import { importedArtifactDataMock } from '../../test/imported-artifacts-data-mock';
+import { artifactWithFixableMainOcrResultsMock, importedArtifactDataMock } from '../../test/imported-artifacts-data-mock';
 import { selectAllArtifacts } from '../../adapters/redux/artifacts/artifacts-selectors';
 import { appStore } from '../../adapters/redux/store';
 import { ArtifactData } from '../../domain/artifacts/models/artifact-data';
@@ -23,6 +23,7 @@ import {
   notArtifactsArrayJsonString,
 } from '../../test/artifacts-from-json';
 import { mockBlobText } from '../../test/blob-text-mock';
+import { wrongMainValueOcrResultsMock } from '../../test/ocr-results-mock';
 
 describe('ArtifactsImporter', () => {
   const artifactsStateChangesSub: Subject<ArtifactData[]> = new Subject();
@@ -110,6 +111,17 @@ describe('ArtifactsImporter', () => {
       });
 
       artifactsImporter.importFromVideo(file, 1, true);
+    });
+
+    it('should fix imported artifact main stat value', (done) => {
+      videoToFramesSpy.mockReturnValue(from([{ frame: artifact0, isLast: true }]));
+      ocrWorkerSpy.mockReturnValue(wrongMainValueOcrResultsMock);
+      artifactsStateChangesSub.pipe(skip(3), take(1)).subscribe((artifactsData) => {
+        expect(getArtifactsWithoutId(artifactsData)).toEqual([artifactWithFixableMainOcrResultsMock]);
+        done();
+      });
+
+      artifactsImporter.importFromVideo(file, 1, true, true);
     });
   });
 

--- a/src/usescases/artifacts/artifacts-importer.spec.ts
+++ b/src/usescases/artifacts/artifacts-importer.spec.ts
@@ -6,13 +6,13 @@ import artifact0bis from '../../test/artifact0bis.jpg';
 import artifact1 from '../../test/artifact1.jpg';
 import artifactWithError from '../../test/artifact-error.jpg';
 import { artifactWithFixableMainOcrResultsMock, importedArtifactDataMock } from '../../test/imported-artifacts-data-mock';
-import { selectAllArtifacts } from '../../adapters/redux/artifacts/artifacts-selectors';
+import { isArtifactsImportRunning, selectAllArtifacts } from '../../adapters/redux/artifacts/artifacts-selectors';
 import { appStore } from '../../adapters/redux/store';
 import { ArtifactData } from '../../domain/artifacts/models/artifact-data';
 import { Unsubscribe } from '@reduxjs/toolkit';
 import { VideoToFrames } from '../../domain/artifacts/mappers/video-to-frames';
 import { Subject, from, interval } from 'rxjs';
-import { skip, take, map, filter } from 'rxjs/operators';
+import { take, map, delay, filter } from 'rxjs/operators';
 import { ArtifactsImporter } from './artifacts-importer';
 import {
   artifactsJsonData,
@@ -58,7 +58,7 @@ describe('ArtifactsImporter', () => {
 
       artifactsStateChangesSub
         .pipe(
-          filter((artifactsData) => artifactsData.length === 16),
+          filter(() => !isArtifactsImportRunning()),
           take(1),
         )
         .subscribe((artifactsData) => {
@@ -83,7 +83,7 @@ describe('ArtifactsImporter', () => {
 
       artifactsStateChangesSub
         .pipe(
-          filter((artifactsData) => artifactsData.length === 2),
+          filter(() => !isArtifactsImportRunning()),
           take(1),
         )
         .subscribe((artifactsData) => {
@@ -104,22 +104,32 @@ describe('ArtifactsImporter', () => {
         ]),
       );
 
-      artifactsStateChangesSub.pipe(skip(4), take(1)).subscribe((artifactsData) => {
-        expect(ocrWorkerSpy).toHaveBeenCalledWith(artifactsOcrImagesMock[0]);
-        expect(getArtifactsWithoutId(artifactsData)).toEqual([importedArtifactDataMock[0]]);
-        done();
-      });
+      artifactsStateChangesSub
+        .pipe(
+          filter(() => !isArtifactsImportRunning()),
+          take(1),
+        )
+        .subscribe((artifactsData) => {
+          expect(ocrWorkerSpy).toHaveBeenCalledWith(artifactsOcrImagesMock[0]);
+          expect(getArtifactsWithoutId(artifactsData)).toEqual([importedArtifactDataMock[0]]);
+          done();
+        });
 
       artifactsImporter.importFromVideo(file, 1, true);
     });
 
-    it('should fix imported artifact main stat value', (done) => {
+    it('should fix imported artifact main stat value', async (done) => {
       videoToFramesSpy.mockReturnValue(from([{ frame: artifact0, isLast: true }]));
-      ocrWorkerSpy.mockReturnValue(wrongMainValueOcrResultsMock);
-      artifactsStateChangesSub.pipe(skip(3), take(1)).subscribe((artifactsData) => {
-        expect(getArtifactsWithoutId(artifactsData)).toEqual([artifactWithFixableMainOcrResultsMock]);
-        done();
-      });
+      ocrWorkerSpy.mockReturnValueOnce(Promise.resolve(wrongMainValueOcrResultsMock));
+      artifactsStateChangesSub
+        .pipe(
+          filter(() => !isArtifactsImportRunning()),
+          take(1),
+        )
+        .subscribe((artifactsData) => {
+          expect(getArtifactsWithoutId(artifactsData)).toEqual([artifactWithFixableMainOcrResultsMock]);
+          done();
+        });
 
       artifactsImporter.importFromVideo(file, 1, true, true);
     });
@@ -225,13 +235,19 @@ describe('ArtifactsImporter', () => {
       ];
       videoToFramesSpy.mockReturnValue(interval(10).pipe(map((val) => frames[val])));
 
-      artifactsStateChangesSub.pipe(skip(9), take(1)).subscribe(() => {
-        expect(artifactsImporter.geImportInfos()).toEqual({ foundFrames: 4, importedArtifacts: 2, artifactsInError: 1 });
-        done();
-      });
+      artifactsStateChangesSub
+        .pipe(
+          filter(() => !isArtifactsImportRunning()),
+          delay(10),
+          take(1),
+        )
+        .subscribe(() => {
+          expect(artifactsImporter.geImportInfos()).toEqual({ foundFrames: 4, importedArtifacts: 2, artifactsInError: 1 });
+          done();
+        });
 
       artifactsImporter.importFromVideo(new File([], 'filename'), 1);
-    }, 10000);
+    }, 12000);
   });
 
   afterEach(() => {

--- a/src/usescases/artifacts/artifacts-importer.ts
+++ b/src/usescases/artifacts/artifacts-importer.ts
@@ -24,7 +24,7 @@ export class ArtifactsImporter {
 
   constructor(private readonly artifactValidator: ArtifactValidator) {}
 
-  public async importFromVideo(video: File, nbOfWorkers: number, overrideCurrentArtifacts = false): Promise<void> {
+  public async importFromVideo(video: File, nbOfWorkers: number, overrideCurrentArtifacts = false, fixOcrErrors = false): Promise<void> {
     appStore.dispatch(importArtifactsFromVideoAction());
     await ArtifactsDI.getArtifactImageOcr().initializeOcr(nbOfWorkers);
 
@@ -35,7 +35,7 @@ export class ArtifactsImporter {
     VideoToFrames.getFrames(video, 10)
       .pipe(takeUntil(this.allFramesRetrieve))
       .subscribe((frameData) => {
-        appStore.dispatch(runOcrOnImageAction(frameData));
+        appStore.dispatch(runOcrOnImageAction({ frameData, fixOcrErrors }));
         if (frameData.isLast) {
           this.allFramesRetrieve.next();
         }


### PR DESCRIPTION
Closes #64 
Closes #63

If fix recognition option has been selected, fix artifacts with wrong main stat value by retrieving it from level and parse artifact string data by checking characters one by one against artifact type, stats type or set names.

Autofix threshold:
- 75% for 4 characters words
- 80% for more than 4 characters words